### PR TITLE
fixed broken link for zeromq

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -171,7 +171,7 @@ projects:
       - text: "The Architecture of Open Source Applications (Volume 2): ZeroMQ"
         url: http://www.aosabook.org/en/zeromq.html
       - text: "Network Autoconfiguration with Go and ØMQ"
-        url: http://www.kyleisom.net/blog/2013/02/26/network-autoconfiguration-with-go-and-zmq/
+        url: https://github.com/kisom/kyleisom.net/blob/master/source/_posts/2013-02-26-network-autoconfiguration-with-go-and-zmq.markdown
       - text: "Using ZeroMQ Security (part 1)"
         url: "http://hintjens.com/blog:48"
       - text: "Integrate ZeroMQ, AMQP, JMS WebSphere MQ and more in 2 lines of Python code with Zato"


### PR DESCRIPTION
The author writes on [kyleisom.net](kyleisom.net):

> I recently lost my original site, and instead of figuring out how far behind my remote Git repo is, I’ve decided to “reboot”. For now, this means there's no proper blog.

Luckily he has that article stored as markdown on github.
