### PR TITLE
Fixing broken link introduced by caplogic/mappedbus entry

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -468,7 +468,7 @@ popular:
       - ipc
     links:
       - text: "Source on GitHub"
-      - url: http://github.com/caplogic/mappedbus 
+        url: http://github.com/caplogic/mappedbus 
 other:
   huey:
     name: huey


### PR DESCRIPTION
Minor entry issue with the yaml file which stops the compile script from executing (currently throws invalid URI error + stack trace)