### PR TITLE
Fix compile error and add siberite

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -466,7 +466,7 @@ popular:
       - ipc
     links:
       - text: "Source on GitHub"
-      - url: http://github.com/caplogic/mappedbus 
+        url: http://github.com/caplogic/mappedbus
 other:
   huey:
     name: huey

--- a/projects.yml
+++ b/projects.yml
@@ -295,6 +295,22 @@ popular:
         url: http://www.railstips.org/blog/archives/2012/03/05/misleading-title-about-queueing/
       - text: "Don't Forget About the Kestrel Messaging Queue"
         url: http://java.dzone.com/articles/dont-forget-about-kestrel
+  siberite:
+    name: Siberite
+    summary: "Simple, lightweight, leveldb backed message queue"
+    url: http://siberite.org/
+    description:
+      - Darner rewritten in Go with additional features
+      - Single topic can be consumed multiple times using durable cursors
+      - Uses Kestrel (memcached) protocol
+      - Keeps all messages out of process
+      - Small amount of in-resident memory regardless of queue size
+      - Two-phase reliable fetch
+    tags:
+      - go
+    links:
+      - text: "Source on GitHub"
+        url: https://github.com/bogdanovich/siberite
   gearman:
     name: Gearman
     summary: Gearman Job Server

--- a/projects.yml
+++ b/projects.yml
@@ -178,7 +178,7 @@ popular:
         url: http://www.slideshare.net/mumrah/kafka-talk-tri-hug
       - text: "Intra-cluster Replication in Apache Kafka"
         url: "http://engineering.linkedin.com/kafka/intra-cluster-replication-apache-kafka"
-  Kue:
+  kue:
     name: Kue
     url: https://github.com/Automattic/kue
     summary: "A distributed priority job queue backed by redis, built for node.js"


### PR DESCRIPTION
- Fix: http://queues.io currently does not reflect latest changes (i.e. does not show Disque), because mappedbus url is incorrect and   causes `bin/ compile` error. The error was introduced in #83 .
- Fix: Kue gets rendered in first place because of capital letter key.
- Add Siberite message queue