### PR TITLE
Removed an outdated reference to a guide that no longer exists.

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -42,6 +42,8 @@ popular:
     links:
       - text: "Developer Guide: What is Amazon Simple Queue Service?"
         url: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/Welcome.html
+      - text: "Developer Guide: Tutorials"
+        url: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html
       - text: "API Reference"
         url: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/Welcome.html
       - text: "What are the advantages and disadvantages of Beanstalkd as a work queue? at Quora"

--- a/projects.yml
+++ b/projects.yml
@@ -40,8 +40,6 @@ popular:
     tags:
       - service
     links:
-      - text: "Getting Started Guide: Welcome"
-        url: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/Welcome.html
       - text: "Developer Guide: What is Amazon Simple Queue Service?"
         url: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/Welcome.html
       - text: "API Reference"


### PR DESCRIPTION
The _Amazon SQS Getting Started Guide_ has been retired. The most current information is in the _Amazon SQS Developer Guide_: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html