### PR TITLE
Add a link to kmq

### DIFF
--- a/projects.yml
+++ b/projects.yml
@@ -193,6 +193,8 @@ popular:
         url: http://www.slideshare.net/mumrah/kafka-talk-tri-hug
       - text: "Intra-cluster Replication in Apache Kafka"
         url: "http://engineering.linkedin.com/kafka/intra-cluster-replication-apache-kafka"
+      - text: "Implementing a traditional message queue on top of Kafka: selective acknowledgments"
+        url: "https://github.com/softwaremill/kmq"
   kue:
     name: Kue
     url: https://github.com/Automattic/kue


### PR DESCRIPTION
I'd like to propose adding a new link to the kafka section, to the kmq project, which implements a "traditional" message queue mechanism on top of Kafka, so that it's possible to individually acknowledge messages.